### PR TITLE
Use fmt.Print instead of the print builtin in stripReader

### DIFF
--- a/deansify.go
+++ b/deansify.go
@@ -4,6 +4,7 @@ package deansify
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -21,7 +22,7 @@ func stripReader(reader *bufio.Reader) {
 	for {
 		line, err := reader.ReadString('\n')
 		if err == nil || err == io.EOF {
-			print(stripAnsi(line))
+			fmt.Print(stripAnsi(line))
 		}
 
 		if err != nil {


### PR DESCRIPTION
The version with `print` didn't work in a shell pipeline on my machine - it just spew everything onto the terminal, leaving the stdin of the subsequent process empty. Not sure why though.
